### PR TITLE
正确的使用 unicodecsv

### DIFF
--- a/jsoncsv/__init__.py
+++ b/jsoncsv/__init__.py
@@ -4,4 +4,4 @@
 
 import sys
 
-PY3 = bool(sys.version_info[0] == 3)
+PY2 = bool(sys.version_info[0] == 2)

--- a/jsoncsv/dumptool.py
+++ b/jsoncsv/dumptool.py
@@ -7,7 +7,7 @@ import unicodecsv as csv
 import json
 import xlwt
 
-from jsoncsv import PY3
+from jsoncsv import PY2
 
 
 class Dump(object):
@@ -96,12 +96,7 @@ class DumpCSV(DumpExcel):
         self.csv_writer = None
 
     def write_headers(self):
-        if not PY3:
-            # Python 2 csv does not support unicode
-            fieldnames = [header.encode('utf8') for header in self._headers]
-        else:
-            fieldnames = self._headers
-        self.csv_writer = csv.DictWriter(self.fout, fieldnames)
+        self.csv_writer = csv.DictWriter(self.fout, self._headers)
         self.csv_writer.writeheader()
 
     def write_obj(self, obj):
@@ -112,12 +107,6 @@ class DumpCSV(DumpExcel):
         for key, value in obj.items():
             if value in [None, {}, []]:
                 value = ""
-
-            if not PY3:
-                # Python 2 csv does not support unicode
-                key = key.encode('utf8')
-                if isinstance(value, six.text_type):
-                    value = value.encode('utf8')
 
             new_obj[key] = value
         return new_obj

--- a/jsoncsv/dumptool.py
+++ b/jsoncsv/dumptool.py
@@ -2,12 +2,9 @@
 # author@alingse
 # 2015.10.09
 
-import six
 import unicodecsv as csv
 import json
 import xlwt
-
-from jsoncsv import PY2
 
 
 class Dump(object):

--- a/jsoncsv/jsontool.py
+++ b/jsoncsv/jsontool.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from itertools import groupby
 from operator import itemgetter
 
-from jsoncsv import PY3
+from jsoncsv import PY2
 from jsoncsv.utils import encode_safe_key
 from jsoncsv.utils import decode_safe_key
 
@@ -32,10 +32,11 @@ def gen_leaf(root, path=None):
         yield leaf
     else:
         if isinstance(root, dict):
-            if PY3:
-                items = root.items()
-            else:
+            if PY2:
                 items = root.iteritems()
+            else:
+                items = root.items()
+
         else:
             items = enumerate(root)
 
@@ -96,10 +97,10 @@ def expand(origin, separator='.', safe=False):
 
     expobj = {}
     for path, value in leafs:
-        if PY3:
-            path = map(str, path)
-        else:
+        if PY2:
             path = map(unicode, path)  # noqa
+        else:
+            path = map(str, path)
 
         if safe:
             key = encode_safe_key(path, separator)
@@ -113,10 +114,10 @@ def expand(origin, separator='.', safe=False):
 def restore(expobj, separator='.', safe=False):
     leafs = []
 
-    if PY3:
-        items = expobj.items()
-    else:
+    if PY2:
         items = expobj.iteritems()
+    else:
+        items = expobj.items()
 
     for key, value in items:
         if safe:
@@ -141,8 +142,9 @@ def convert_json(fin, fout, func, separator=".", safe=False):
         obj = json.loads(line)
         new = func(obj, separator=separator, safe=safe)
         content = json.dumps(new, ensure_ascii=False)
-        if PY3:
-            fout.write(content)
-        else:
+        if PY2:
             fout.write(content.encode('utf-8'))
+        else:
+            fout.write(content)
+
         fout.write(str('\n'))

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with io.open('README.rst', encoding='utf-8') as f:
 
 setup(
     name='jsoncsv',
-    version='2.2.0',
+    version='2.2.1',
     url='https://github.com/alingse/jsoncsv',
     description='A command tool easily convert json file to csv or xlsx.',
     long_description=readme,

--- a/tests/test_jsontool.py
+++ b/tests/test_jsontool.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import io
 import unittest
 
-from jsoncsv import PY3
+from jsoncsv import PY2
 from jsoncsv.jsontool import expand, restore
 from jsoncsv.jsontool import is_array
 from jsoncsv.jsontool import convert_json
@@ -95,10 +95,10 @@ class TestConvertJSON(unittest.TestCase):
 
     def test_convert_expand(self):
         fin = io.StringIO('{"a":{"b":3}}\n{"a":{"c":4}}\n')
-        if PY3:
-            fout = io.StringIO()
-        else:
+        if PY2:
             fout = io.BytesIO()
+        else:
+            fout = io.StringIO()
 
         convert_json(fin, fout, expand)
 
@@ -109,10 +109,10 @@ class TestConvertJSON(unittest.TestCase):
 
     def test_convert_restore(self):
         fin = io.StringIO('{"a.b": 3}\n{"a.c": 4}\n')
-        if PY3:
-            fout = io.StringIO()
-        else:
+        if PY2:
             fout = io.BytesIO()
+        else:
+            fout = io.StringIO()
 
         convert_json(fin, fout, restore)
 


### PR DESCRIPTION
- 去掉 PY3
- 使用 PY2 来表明兼容
- 去掉 six
- 正确使用 unicodecsv (headers 不需要编码，字符也不需要编码）统一 unicode